### PR TITLE
Using new context API

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,4 @@
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": false,
-  "parser": "flow"
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This can become quite a bit of work to add a single field and if you miss a spot
 
 This component receives the values and validation rules as props and renders your validated form using render props. The `CheckSome` component performs all the data validation and passes form state (such as `valid` or `changed`) to the form. The `CheckSome.Field` component accepts a render prop to render a specific field along with any validation errors and whether the field has been touched yet. This solution abstracts the validation logic while keeping flexibility for how to render error messages.
 
+## Requirements
+
+As of v1.0.0, check-some uses react hooks, so you need to have React 16.8 or higher installed
+
 ## Installation
 
 ```bash
@@ -83,9 +87,12 @@ Validation rules are defined as functions that take the value of a field and ret
 You could then use this to render a cusomized error message
 
 ```jsx
-{errors && errors.greaterThanFive && (
-  <div>Value needs to be greater than 5, but was {errors.greaterThanFive.value}.</div>
-)}
+{
+  errors &&
+    errors.greaterThanFive && (
+      <div>Value needs to be greater than 5, but was {errors.greaterThanFive.value}.</div>
+    );
+}
 ```
 
 ## Components
@@ -95,21 +102,25 @@ You could then use this to render a cusomized error message
 #### Props
 
 ##### `values` - Object containing all the values of the form
+
 ```
 {[key:string]: any}
 ```
 
 #### `rules` (optional) - Object containing rules for all values (keys should match values set in `values`)
+
 ```
 {[key:string]: null | {[errorName:string]: Object}}
 ```
 
 ##### `initialValues` (optional) - Object containing values to check against when finding out if form has changed
+
 ```
 {[key:string]: any}
 ```
 
 ##### `children` - Render prop for rendering the form
+
 ```
 (props: ChildProps) => React.Node
 ```
@@ -117,12 +128,15 @@ You could then use this to render a cusomized error message
 #### ChildProps (Props that will be passed to the render prop for `CheckSome`)
 
 ##### `valid` - If all the validation rules have passed
+
 `boolean`
 
 ##### `changed` - If all the values have changed since the component mounted (or if the same as `props.initialValues` if set)
+
 `boolean`
 
 ##### `errors` - Description of all the validation errors by field
+
 ```
 {
   [key:string]: null | {[errorName:string]: Object}
@@ -136,6 +150,7 @@ You could then use this to render a cusomized error message
 ##### `name` - The field to render (needs to match a key in `values` passed to `CheckSome`)
 
 ##### `children` - Render prop for rendering the field
+
 ```
 (props: ChildProps) => React.Node
 ```
@@ -143,17 +158,21 @@ You could then use this to render a cusomized error message
 #### ChildProps
 
 ##### `value` - The value passed in `values` of `CheckSome` that matches the name set in `CheckSome.Field`
+
 `any`
 
 ##### `errors` - Description of the validation errors for the field
+
 ```
 null | {[errorName:string]: Object}
 ```
 
 ##### `valid` - If the validation rules for the field have passed
+
 `boolean`
 
 ##### `touched` - If the field has been focused and blured
+
 `boolean`
 
 ## License

--- a/example/package.json
+++ b/example/package.json
@@ -6,9 +6,8 @@
   "dependencies": {
     "check-some": "0.0.1",
     "material-ui": "^0.20.0",
-    "prop-types": "^15.4.4",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "react-modern-library-boilerplate": "^1.0.0",
     "react-scripts": "^2.1.5"
   },
@@ -21,10 +20,5 @@
   "resolutions": {
     "jest": "24.1.0"
   },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ]
+  "browserslist": [">0.2%", "not dead", "not ie <= 11", "not op_mini all"]
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -7072,7 +7072,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15.4.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.6.0:
+prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -7264,7 +7264,7 @@ react-dev-utils@^7.0.3:
     strip-ansi "5.0.0"
     text-table "0.2.0"
 
-react-dom@^16.0.0:
+react-dom@^16.8.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
   dependencies:
@@ -7358,7 +7358,7 @@ react-transition-group@^1.2.1:
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-react@^16.0.0:
+react@^16.8.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
   dependencies:

--- a/package.json
+++ b/package.json
@@ -24,23 +24,16 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "src/**/*.js": [
-      "prettier --write",
-      "git add"
-    ]
+    "src/**/*.js": ["prettier --write", "git add"]
   },
   "jest": {
-    "modulePaths": [
-      "src",
-      "node_modules"
-    ],
+    "modulePaths": ["src", "node_modules"],
     "rootDir": ".",
     "notify": true
   },
   "peerDependencies": {
-    "prop-types": "^15.5.4",
-    "react": "^0.14.9 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.9 || ^15.0.0 || ^16.0.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -93,8 +86,6 @@
     "rollup-plugin-postcss": "^0.5.5",
     "typescript": "^3.6.2"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "dependencies": {}
 }

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -1,49 +1,31 @@
-import React from 'react';
-import * as PropTypes from 'prop-types';
-import {CHECK_SOME_CONTEXT} from './globals';
+import React, {useState, useContext} from 'react';
+import {CheckSomeContext} from './CheckSome';
 import {ValidationErrors} from './globals';
 
 type CheckSomeFieldChildProps<T> = {
-  value: T,
-  errors: ValidationErrors | null,
-  touched: boolean,
-  valid: boolean,
+  value: T;
+  errors: ValidationErrors | null;
+  touched: boolean;
+  valid: boolean;
 };
 
 type Props = {
-  name: string,
-  children: (props: CheckSomeFieldChildProps<any>) => React.ReactNode,
+  name: string;
+  children: (props: CheckSomeFieldChildProps<any>) => React.ReactNode;
 };
 
-type State = {
-  touched: boolean,
+const CheckSomeField = ({name, children}: Props) => {
+  const [touched, setTouched] = useState(false);
+  const {values, errors: formErrors} = useContext(CheckSomeContext);
+  const value = values[name];
+  const errors = formErrors ? formErrors[name] : null;
+  const valid = !errors;
+
+  return (
+    <div className="CheckSomeField" onBlur={() => setTouched(true)}>
+      {children({value, errors, touched, valid})}
+    </div>
+  );
 };
 
-export default class CheckSomeField extends React.Component<Props, State> {
-  state = {
-    touched: false,
-  };
-
-  static contextTypes = {
-    [CHECK_SOME_CONTEXT]: PropTypes.object.isRequired,
-  };
-
-  markFieldTouched = () => {
-    this.setState({touched: true});
-  };
-
-  render() {
-    const {values, errors: formErrors} = this.context[CHECK_SOME_CONTEXT];
-    const {name} = this.props;
-    const {touched} = this.state;
-    const value = values[name];
-    const errors = formErrors ? formErrors[name] : null;
-    const valid = !errors;
-
-    return (
-      <div className="CheckSomeField" onBlur={this.markFieldTouched}>
-        {this.props.children({value, errors, touched, valid})}
-      </div>
-    );
-  }
-}
+export default CheckSomeField;

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,3 +1,1 @@
-export const CHECK_SOME_CONTEXT = '__check_some__';
-
 export type ValidationErrors = {[key: string]: Object}; // TODO: Check object shape somehow


### PR DESCRIPTION
Updated the component to use some new react features.

The API for the component didn't change, but this is a breaking change since the new react context API requires react >= 16.3 and I used hooks to implement it, which requires react >= 16.8

Fixes #6 