### PR TITLE
Add type checking for rules

### DIFF
--- a/src/CheckSome.tsx
+++ b/src/CheckSome.tsx
@@ -3,32 +3,28 @@ import isEqual from 'lodash/isEqual';
 import CheckSomeField from './Field';
 import {ValidationErrors} from './globals';
 
-type ValidationRule = (value: any) => ValidationErrors | null;
+type ValidationRule<T> = (value: T) => ValidationErrors | null;
 
-type ValidationGroupRules = {[name: string]: Array<ValidationRule>};
-type ValidationGroupErrors = {[name: string]: ValidationErrors} | null;
+type ValidationGroupValues<T> = {[K in keyof T]: T[K]};
+type ValidationGroupRules<T> = Partial<{[K in keyof T]: Array<ValidationRule<T[K]>>}>;
+type ValidationGroupErrors<T> = Partial<{[K in keyof T]: ValidationErrors}> | null;
 
-export type CheckSomeChildProps = {
+export type CheckSomeChildProps<T> = {
   valid: boolean;
   changed: boolean;
-  errors: ValidationGroupErrors;
+  errors: ValidationGroupErrors<T>;
 };
 
-export type CheckSomeProps = {
-  rules: ValidationGroupRules;
-  values: {[key: string]: any}; // TODO: Get a better type here
-  initialValues?: {[key: string]: any};
-  children: (props: CheckSomeChildProps) => React.ReactNode;
+export type CheckSomeProps<T> = {
+  rules: ValidationGroupRules<T>;
+  values: ValidationGroupValues<T>;
+  initialValues?: ValidationGroupValues<T>;
+  children: (props: CheckSomeChildProps<T>) => React.ReactNode;
 };
 
-interface Context {
-  values: {[key: string]: any};
-  errors: ValidationGroupErrors;
-}
+export const CheckSomeContext = createContext({});
 
-export const CheckSomeContext = createContext<Context>({values: {}, errors: {}});
-
-export default class CheckSome extends React.Component<CheckSomeProps> {
+export default class CheckSome<T> extends React.Component<CheckSomeProps<T>> {
   static Field = CheckSomeField;
 
   static defaultProps = {
@@ -49,13 +45,15 @@ export default class CheckSome extends React.Component<CheckSomeProps> {
     return this.initialValues;
   };
 
-  getErrors = (): ValidationGroupErrors =>
-    Object.keys(this.props.rules).reduce((errors: ValidationGroupErrors, key) => {
+  getErrors = (): ValidationGroupErrors<T> =>
+    Object.keys(this.props.rules).reduce((errors: ValidationGroupErrors<T>, keyValue) => {
+      // @ts-ignore
+      const key: keyof T = keyValue;
       const rules = this.props.rules[key];
       const value = this.props.values[key];
 
-      const newErrors = rules.reduce(
-        (e: ValidationErrors | null, rule: ValidationRule) => e || rule(value),
+      const newErrors = rules!.reduce(
+        (e: ValidationErrors | null, rule: ValidationRule<T[typeof key]>) => e || rule(value),
         null,
       );
 
@@ -87,3 +85,29 @@ export default class CheckSome extends React.Component<CheckSomeProps> {
     );
   }
 }
+
+const greaterThanZero = (value: number) => {
+  return value > 0 ? null : {greaterThanZero: {value}};
+};
+
+const startsWith = (startingText: string) => (value: string) =>
+  value.startsWith(startingText) ? null : {startsWith: {startingText, value}};
+
+const tsCheck = (
+  <CheckSome
+    values={{
+      stringField: 'string',
+      numberField: 7,
+    }}
+    initialValues={{
+      stringField: 'string',
+      numberField: 7,
+    }}
+    rules={{
+      stringField: [startsWith('test')],
+      numberField: [greaterThanZero],
+    }}
+  >
+    {() => <div />}
+  </CheckSome>
+);

--- a/src/CheckSome.tsx
+++ b/src/CheckSome.tsx
@@ -22,7 +22,10 @@ export type CheckSomeProps<T> = {
   children: (props: CheckSomeChildProps<T>) => React.ReactNode;
 };
 
-export const CheckSomeContext = createContext({});
+export const CheckSomeContext = createContext<{
+  values: {[key: string]: any};
+  errors: {[key: string]: ValidationErrors | undefined} | null;
+}>({values: {}, errors: {}});
 
 export default class CheckSome<T> extends React.Component<CheckSomeProps<T>> {
   static Field = CheckSomeField;
@@ -85,29 +88,3 @@ export default class CheckSome<T> extends React.Component<CheckSomeProps<T>> {
     );
   }
 }
-
-const greaterThanZero = (value: number) => {
-  return value > 0 ? null : {greaterThanZero: {value}};
-};
-
-const startsWith = (startingText: string) => (value: string) =>
-  value.startsWith(startingText) ? null : {startsWith: {startingText, value}};
-
-const tsCheck = (
-  <CheckSome
-    values={{
-      stringField: 'string',
-      numberField: 7,
-    }}
-    initialValues={{
-      stringField: 'string',
-      numberField: 7,
-    }}
-    rules={{
-      stringField: [startsWith('test')],
-      numberField: [greaterThanZero],
-    }}
-  >
-    {() => <div />}
-  </CheckSome>
-);

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -18,7 +18,7 @@ const CheckSomeField = ({name, children}: Props) => {
   const [touched, setTouched] = useState(false);
   const {values, errors: formErrors} = useContext(CheckSomeContext);
   const value = values[name];
-  const errors = formErrors ? formErrors[name] : null;
+  const errors = (formErrors && formErrors[name]) || null;
   const valid = !errors;
 
   return (

--- a/test/__snapshots__/CheckSome.test.tsx.snap
+++ b/test/__snapshots__/CheckSome.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`CheckSome blurring the fields sets the touched prop for fields 1`] = `
         </div>
         <div>
           Field Errors: 
+          null
         </div>
       </div>
     </div>
@@ -159,6 +160,7 @@ exports[`CheckSome renders the initial form 1`] = `
         </div>
         <div>
           Field Errors: 
+          null
         </div>
       </div>
     </div>
@@ -198,6 +200,7 @@ exports[`CheckSome setting values to something still invalid updates changed, va
         </div>
         <div>
           Field Errors: 
+          null
         </div>
       </div>
     </div>
@@ -241,6 +244,7 @@ exports[`CheckSome setting values to something still invalid updates changed, va
         </div>
         <div>
           Field Errors: 
+          null
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #26 

This didn't get as far as I wanted it to get because of how react context works, but it's definitely a step in the right direction.

I added some generics which does some basic type checking for the rules and values. TS should now validate the following

## Checks
- `values` and `initialValues` need to have the same types
- `rules` can't have a rule for a property that isn't defined in `values`
- Validator functions defined in `rules` need to have an input with a type that matches that key in `rules`
- If `initalValues` is specified, it needs to have all the properties on `values`

## Limitations
- `CheckSome.Field` doesn't have a good type definition for `value` from the name